### PR TITLE
Fix location filter to respect active scope

### DIFF
--- a/app/Models/Property.php
+++ b/app/Models/Property.php
@@ -120,9 +120,11 @@ class Property extends Model
 
     public function scopeByLocation(Builder $query, string $location)
     {
-        return $query->where('city', 'like', "%{$location}%")
-                    ->orWhere('state', 'like', "%{$location}%")
-                    ->orWhere('address', 'like', "%{$location}%");
+        return $query->where(function (Builder $query) use ($location) {
+            $query->where('city', 'like', "%{$location}%")
+                  ->orWhere('state', 'like', "%{$location}%")
+                  ->orWhere('address', 'like', "%{$location}%");
+        });
     }
 
     // Accessors & Mutators
@@ -195,6 +197,4 @@ class Property extends Model
     {
         return '$' . number_format($this->price, 0);
     }
-
-    // Add this method to your Property model
 }

--- a/tests/Feature/PropertyScopeTest.php
+++ b/tests/Feature/PropertyScopeTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Property;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PropertyScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_by_location_scope_respects_active_properties(): void
+    {
+        $active = Property::create([
+            'title' => 'Active Property',
+            'slug' => 'active-property',
+            'description' => 'A lovely active property.',
+            'address' => '123 Main St',
+            'city' => 'Sample City',
+            'state' => 'NY',
+            'postal_code' => '10001',
+            'country' => 'USA',
+            'type' => 'residential',
+            'price' => 100000,
+            'status' => 'for_sale',
+            'is_active' => true,
+        ]);
+
+        $inactive = Property::create([
+            'title' => 'Inactive Property',
+            'slug' => 'inactive-property',
+            'description' => 'An inactive property.',
+            'address' => '456 Side St',
+            'city' => 'Another City',
+            'state' => 'NY',
+            'postal_code' => '10002',
+            'country' => 'USA',
+            'type' => 'residential',
+            'price' => 90000,
+            'status' => 'for_sale',
+            'is_active' => false,
+        ]);
+
+        $results = Property::active()->byLocation('NY')->pluck('id');
+
+        $this->assertTrue($results->contains($active->id));
+        $this->assertFalse($results->contains($inactive->id));
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure property `byLocation` scope groups OR conditions so `active` scope isn't bypassed
- add regression test verifying inactive properties are excluded when filtering by location

## Testing
- `vendor/bin/phpunit tests/Feature/PropertyScopeTest.php` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68919b4647f4832397651bd18b3450a3